### PR TITLE
fix(prettier-config): add override for pnpm-lock.yaml

### DIFF
--- a/packages/prettier-config/src/index.ts
+++ b/packages/prettier-config/src/index.ts
@@ -9,6 +9,14 @@ const config: Config = {
 	bracketSpacing: true,
 	arrowParens: "always",
 	endOfLine: "lf",
+	overrides: [
+		{
+			files: ["pnpm-lock.yaml"],
+			options: {
+				requirePragma: true,
+			},
+		},
+	],
 };
 
 export default config;


### PR DESCRIPTION
Added a configs override to require pragma notation in pnpm-lock.yaml which ignores that file.