### PR TITLE
fix(eslint-config): add ignores to exclude build directories

### DIFF
--- a/packages/eslint-config-base/src/index.ts
+++ b/packages/eslint-config-base/src/index.ts
@@ -10,6 +10,7 @@ const config = [
 		languageOptions: {
 			ecmaVersion: "latest",
 		},
+		ignores: [".next", "dist", ".wrangler", ".vercel", ".turbo", ".yarn"],
 		plugins: {
 			/**
 			 * eslint-plugin-import is not yet compatible with ESLint v9.


### PR DESCRIPTION
The added ignores ensure that build directories are excluded from linting, preventing unnecessary linting errors.