### PR TITLE
feat(eslint): add unused-imports plugin and update rules

### DIFF
--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -43,7 +43,8 @@
 	"prettier": "@abinnovision/prettier-config",
 	"dependencies": {
 		"eslint-config-alloy": "^5.1.2",
-		"eslint-plugin-import": "^2.31.0"
+		"eslint-plugin-import": "^2.31.0",
+		"eslint-plugin-unused-imports": "^4.1.4"
 	},
 	"devDependencies": {
 		"@abinnovision/prettier-config": "workspace:^",

--- a/packages/eslint-config-base/src/index.ts
+++ b/packages/eslint-config-base/src/index.ts
@@ -1,5 +1,6 @@
 import AlloyBase from "eslint-config-alloy/base.js";
 import eslintPluginImport from "eslint-plugin-import";
+import unusedImports from "eslint-plugin-unused-imports";
 
 import type { Linter } from "eslint";
 
@@ -9,7 +10,6 @@ const config = [
 		languageOptions: {
 			ecmaVersion: "latest",
 		},
-		ignores: [".next", "dist", ".wrangler", ".vercel", ".turbo", ".yarn"],
 		plugins: {
 			/**
 			 * eslint-plugin-import is not yet compatible with ESLint v9.
@@ -18,6 +18,7 @@ const config = [
 			 * @see https://github.com/import-js/eslint-plugin-import/issues/2948
 			 */
 			import: eslintPluginImport,
+			"unused-imports": unusedImports,
 		},
 		rules: {
 			/**
@@ -78,6 +79,21 @@ const config = [
 			 * Disable the "no-return-await" rule.
 			 */
 			"no-return-await": "off",
+
+			/**
+			 * Disable the "no-unused-vars" rule as unused-imports is used instead.
+			 */
+			"no-unused-vars": "off",
+			"unused-imports/no-unused-imports": "error",
+			"unused-imports/no-unused-vars": [
+				"warn",
+				{
+					vars: "all",
+					varsIgnorePattern: "^_",
+					args: "after-used",
+					argsIgnorePattern: "^_",
+				},
+			],
 		},
 	},
 ] satisfies Linter.Config[];

--- a/packages/eslint-config-typescript/src/index.ts
+++ b/packages/eslint-config-typescript/src/index.ts
@@ -36,6 +36,11 @@ const config = [
 			 * @see https://stackoverflow.com/questions/43353087/are-there-performance-concerns-with-return-await/70979225#70979225
 			 */
 			"@typescript-eslint/return-await": ["warn", "always"],
+
+			/**
+			 * Disable no-unused-vars due to unused-imports plugin
+			 */
+			"@typescript-eslint/no-unused-vars": "off",
 		},
 	},
 ] satisfies Linter.Config[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,7 @@ __metadata:
     eslint: "npm:^9.13.0"
     eslint-config-alloy: "npm:^5.1.2"
     eslint-plugin-import: "npm:^2.31.0"
+    eslint-plugin-unused-imports: "npm:^4.1.4"
     globals: "npm:^15.11.0"
     prettier: "npm:^3.3.3"
     tsup: "npm:^8.3.0"
@@ -2208,6 +2209,19 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
   checksum: 10/a7b9cf2c43255844ad0c9d4e3758a8c2b687a2ce9a09f4161ab245581d5d2d91b37742e541c88aa9ce368ec6c860e23dc78c15117f3fc1cdc433847038e8346b
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-unused-imports@npm:^4.1.4":
+  version: 4.1.4
+  resolution: "eslint-plugin-unused-imports@npm:4.1.4"
+  peerDependencies:
+    "@typescript-eslint/eslint-plugin": ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+    eslint: ^9.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@typescript-eslint/eslint-plugin":
+      optional: true
+  checksum: 10/8e987028ad925ce1e04c01dcae70adbf44c2878a8b15c4327b33a2861e471d7fe00f6fe213fbd2b936f3fcefc8ccabb0d778aa1d6e0e0387a3dc7fe150cd4ed4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Integrate eslint-plugin-unused-imports to improve unused code detection. Disable existing no-unused-vars rules and configure unused-imports rules for better control. Update yarn.lock to include the new dependency.