### PR TITLE
chore: add package support metadata

### DIFF
--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "@abinnovision/commitlint-config",
 	"version": "2.3.0",
+	"homepage": "https://github.com/abinnovision/js-commons",
+	"bugs": {
+		"url": "https://github.com/abinnovision/js-commons/issues"
+	},
 	"repository": {
 		"url": "https://github.com/abinnovision/js-commons"
 	},

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "@abinnovision/eslint-config-base",
 	"version": "3.4.1",
+	"homepage": "https://github.com/abinnovision/js-commons",
+	"bugs": {
+		"url": "https://github.com/abinnovision/js-commons/issues"
+	},
 	"repository": {
 		"url": "https://github.com/abinnovision/js-commons"
 	},

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "@abinnovision/eslint-config-react",
 	"version": "3.2.0",
+	"homepage": "https://github.com/abinnovision/js-commons",
+	"bugs": {
+		"url": "https://github.com/abinnovision/js-commons/issues"
+	},
 	"repository": {
 		"url": "https://github.com/abinnovision/js-commons"
 	},

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "@abinnovision/prettier-config",
 	"version": "2.2.0",
+	"homepage": "https://github.com/abinnovision/js-commons",
+	"bugs": {
+		"url": "https://github.com/abinnovision/js-commons/issues"
+	},
 	"repository": {
 		"url": "https://github.com/abinnovision/js-commons"
 	},


### PR DESCRIPTION
## Summary
- add missing `homepage` metadata to the published package manifests
- add `bugs.url` pointing to the repository issue tracker
- keep the private internal tsconfig package unchanged

## Packages
- `@abinnovision/eslint-config-react`
- `@abinnovision/eslint-config-base`
- `@abinnovision/prettier-config`
- `@abinnovision/commitlint-config`

## Verification
- package metadata assertion for all four manifests
- `npm pack --dry-run --ignore-scripts --json` in each changed package directory
- `npx --yes sort-package-json@2.15.1 'packages/*/package.json' 'package.json' --check`
- `git diff --check`

This is a package manifest-only change; runtime code, dependencies, exports, generated output, and package versioning are unchanged.