### PR TITLE
build: complete npm metadata for published packages

### DIFF
--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -1,12 +1,20 @@
 {
 	"name": "@abinnovision/commitlint-config",
 	"version": "2.3.0",
+	"description": "Commitlint configuration based on Conventional Commits with abi group GmbH adjustments.",
+	"keywords": [
+		"commitlint",
+		"commitlint-config",
+		"conventional-commits"
+	],
 	"homepage": "https://github.com/abinnovision/js-commons",
 	"bugs": {
 		"url": "https://github.com/abinnovision/js-commons/issues"
 	},
 	"repository": {
-		"url": "https://github.com/abinnovision/js-commons"
+		"type": "git",
+		"url": "git+https://github.com/abinnovision/js-commons.git",
+		"directory": "packages/commitlint-config"
 	},
 	"license": "Apache-2.0",
 	"author": {

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,12 +1,21 @@
 {
 	"name": "@abinnovision/eslint-config-base",
 	"version": "3.4.1",
+	"description": "Shared ESLint configuration for JavaScript and TypeScript projects.",
+	"keywords": [
+		"eslint",
+		"eslint-config",
+		"typescript",
+		"javascript"
+	],
 	"homepage": "https://github.com/abinnovision/js-commons",
 	"bugs": {
 		"url": "https://github.com/abinnovision/js-commons/issues"
 	},
 	"repository": {
-		"url": "https://github.com/abinnovision/js-commons"
+		"type": "git",
+		"url": "git+https://github.com/abinnovision/js-commons.git",
+		"directory": "packages/eslint-config-base"
 	},
 	"license": "Apache-2.0",
 	"author": {

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,12 +1,21 @@
 {
 	"name": "@abinnovision/eslint-config-react",
 	"version": "3.2.0",
+	"description": "Shared ESLint configuration for React applications, building on @abinnovision/eslint-config-base.",
+	"keywords": [
+		"eslint",
+		"eslint-config",
+		"react",
+		"typescript"
+	],
 	"homepage": "https://github.com/abinnovision/js-commons",
 	"bugs": {
 		"url": "https://github.com/abinnovision/js-commons/issues"
 	},
 	"repository": {
-		"url": "https://github.com/abinnovision/js-commons"
+		"type": "git",
+		"url": "git+https://github.com/abinnovision/js-commons.git",
+		"directory": "packages/eslint-config-react"
 	},
 	"license": "Apache-2.0",
 	"author": {

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,12 +1,21 @@
 {
 	"name": "@abinnovision/prettier-config",
 	"version": "2.2.0",
+	"description": "Shared Prettier configuration with an opinionated .editorconfig.",
+	"keywords": [
+		"prettier",
+		"prettier-config",
+		"editorconfig",
+		"formatting"
+	],
 	"homepage": "https://github.com/abinnovision/js-commons",
 	"bugs": {
 		"url": "https://github.com/abinnovision/js-commons/issues"
 	},
 	"repository": {
-		"url": "https://github.com/abinnovision/js-commons"
+		"type": "git",
+		"url": "git+https://github.com/abinnovision/js-commons.git",
+		"directory": "packages/prettier-config"
 	},
 	"license": "Apache-2.0",
 	"author": {


### PR DESCRIPTION
Adds the recommended npm metadata that the four published packages were missing: a `description` and `keywords` for discoverability, plus a normalized `repository` field in the canonical monorepo form (`type`, `git+https` URL, and per-package `directory`). The `bugs` and `homepage` fields were already present and correct, so they are untouched, and the private packages are intentionally left unchanged. Verified with `yarn build` (which runs `publint` clean), `yarn sort:check`, and `yarn format:check`.